### PR TITLE
Changed output of library on windows to libvespucci.lib

### DIFF
--- a/Test/Test.pro
+++ b/Test/Test.pro
@@ -136,7 +136,7 @@ unix:!macx: DEPENDPATH += /usr/local/include/cminpack-1
 win32:!win32-g++{
     CONFIG += release force_debug_info
 
-    LIBS += -L$$OUT_PWD/../VespucciLibrary/release -lvespucci
+    LIBS += -L$$OUT_PWD/../VespucciLibrary/release -llibvespucci
     PRE_TARGETDEPS += $$OUT_PWD/../VespucciLibrary/release/vespucci.lib
 
     LIBS += -L$$PWD/../../Vespucci_dependencies/mlpack/lib/ -lmlpack

--- a/Vespucci/Vespucci.pro
+++ b/Vespucci/Vespucci.pro
@@ -424,7 +424,7 @@ macx: LIBS += -lz.1
 win32:!win32-g++{
     CONFIG += release force_debug_info
 
-    LIBS += -L$$OUT_PWD/../VespucciLibrary/release -lvespucci
+    LIBS += -L$$OUT_PWD/../VespucciLibrary/release -llibvespucci
     PRE_TARGETDEPS += $$OUT_PWD/../VespucciLibrary/release/vespucci.lib
 
     LIBS += -L$$PWD/../../Vespucci_dependencies/mlpack/lib/ -lmlpack

--- a/VespucciLibrary/VespucciLibrary.pro
+++ b/VespucciLibrary/VespucciLibrary.pro
@@ -42,10 +42,10 @@ isEmpty(PREFIX) {
     PREFIX = $$PWD/../../Vespucci-install
 }
 travis_ci = $$(TRAVIS_CI)
-deploy_win64 = $$(DEPLOY_WIN64)
-develop_win64 = $$(DEVELOP_WIN64)
+
 # it is assumed that casual windows users will not use the build system to install
-TARGET = vespucci
+!win32:TARGET = vespucci
+win32:TARGET = libvespucci
 TEMPLATE = lib
 DEFINES += VESPUCCI_LIBRARY
 

--- a/copywinlibs.bat
+++ b/copywinlibs.bat
@@ -3,4 +3,5 @@ IF NOT EXIST "Vespucci\release\libgfortran-3.dll" copy /y "..\Vespucci_dependenc
 IF NOT EXIST "Vespucci\release\libopenblas.dll" copy /y "..\Vespucci_dependencies\DLL\libopenblas.dll" "Vespucci\release"
 IF NOT EXIST "Vespucci\release\libquadmath-0.dll" copy /y "..\Vespucci_dependencies\DLL\libquadmath-0.dll" "Vespucci\release"
 IF NOT EXIST "Vespucci\release\lapack_x64.dll" copy /y "..\Vespucci_dependencies\DLL\lapack_x64.dll" "Vespucci\release"
-copy /y "VespucciLibrary\release\vespucci.dll" "Vespucci\release"
+copy /y "VespucciLibrary\release\libvespucci.dll" "Vespucci\release"
+copy /y "VespucciLibrary\release\libvespucci.pdb"


### PR DESCRIPTION
libvespucci.pdb can be copied to the vespucci.exe release folder and the
debugger can work (I hope, I sadly don't know much about the windows debugger)
