### PR TITLE
Removed OpenMP parallelization, new accessory function

### DIFF
--- a/VespucciLibrary/include/Math/Accessory/accessory.h
+++ b/VespucciLibrary/include/Math/Accessory/accessory.h
@@ -97,6 +97,8 @@ namespace Vespucci
         VESPUCCI_EXPORT arma::cx_vec cx_zeros(arma::uword n);
         VESPUCCI_EXPORT arma::cx_mat cx_zeros(arma::uword m, arma::uword n);
 
+        VESPUCCI_EXPORT arma::uword ClosestIndex(double value, const arma::vec &vector);
+
     }
 }
 

--- a/VespucciLibrary/src/Math/Accessory/accessory.cpp
+++ b/VespucciLibrary/src/Math/Accessory/accessory.cpp
@@ -952,3 +952,17 @@ arma::cx_vec Vespucci::Math::cx_zeros(arma::uword n)
 {
     return arma::cx_vec(arma::zeros(n), arma::zeros(n));
 }
+
+arma::uword Vespucci::Math::ClosestIndex(double value, const arma::vec &vector)
+{
+    double delta = std::abs(vector(1) - vector(0)); //assumes monotonic to some degree of precision
+    arma::uvec indices = find(((value-delta) <= vector) && (abscissa <= (value+delta)));
+
+
+    arma::uword index;
+    if (indices.n_elem) index = indices(0);
+    else if (!indices.n_elem && value < vector.min()) index = 0;
+    else index = vector.n_elem - 1;
+
+    return index;
+}

--- a/VespucciLibrary/src/Math/Quantification/correlation.cpp
+++ b/VespucciLibrary/src/Math/Quantification/correlation.cpp
@@ -24,10 +24,8 @@ arma::mat Vespucci::Math::Quantification::CorrelationMat(const arma::mat &X, con
     arma::mat results;
     results.set_size(X.n_cols, control.n_cols);
 
-#pragma omp parallel for default(none) \
-    shared(X, control, results)
-    for (intmax_t i = 0; i < X.n_cols; ++i)
-        for (intmax_t j = 0; j < control.n_cols; ++j)
+    for (arma::uword i = 0; i < X.n_cols; ++i)
+        for (arma::uword j = 0; j < control.n_cols; ++j)
             results(i, j) = arma::as_scalar(arma::cor(control.col(i), X.col(j)));
     return results;
 }

--- a/VespucciLibrary/src/Math/Quantification/quantification.cpp
+++ b/VespucciLibrary/src/Math/Quantification/quantification.cpp
@@ -40,12 +40,10 @@ arma::rowvec Vespucci::Math::Quantification::QuantifyPeak(const arma::vec &spect
 {
     //performs analysis of peak shape and magnitude
     arma::rowvec results(8);
-    double delta = std::abs(abscissa(1) - abscissa(0)); //assumes monotonic to some degree of precision
-    arma::uvec left_bound = find(((min-delta) <= abscissa) && (abscissa <= (min+delta)));
-    arma::uvec right_bound = find(((max-delta) <= abscissa) && (abscissa <= (max+delta)));
-    //initial centers
-    arma::uword min_index = left_bound(0);
-    arma::uword max_index = right_bound(0);
+
+    arma::uword min_index = Vespucci::Math::ClosestIndex(min, abscissa);
+    arma::uword max_index = Vespucci::Math::ClosestIndex(max, abscissa);
+
     min = abscissa(min_index);
     max = abscissa(max_index);
 
@@ -143,7 +141,9 @@ arma::mat Vespucci::Math::Quantification::QuantifyPeakMat(const arma::mat &spect
     arma::mat results(spectra.n_cols, 8);
     inflection_baselines.clear();
     total_baselines.clear();
+    //total_baselines.set_size(spectra.n_cols, )
     inflection_baselines.set_size(spectra.n_cols);
+
     for (arma::uword i = 0; i < spectra.n_cols; ++i){
         double temp_min = min;
         double temp_max = max;


### PR DESCRIPTION
specified value. Removed OpenMP experiment with correlation due to
possible overflow error for very large matrices (n > 2^31) which
Vespucci theoretically supports.
