### PR TITLE
A PR that should be 3 PRs, sorry

### DIFF
--- a/Vespucci/Data/Dataset/vespuccidataset.cpp
+++ b/Vespucci/Data/Dataset/vespuccidataset.cpp
@@ -1831,19 +1831,20 @@ void VespucciDataset::KMeans(size_t clusters, QString metric_text, QString name)
         clusters = HySime();
         log_text_stream_ << clusters << endl;
     }
-    mat k_means_data;
+    mat assignments;
+    mat centroids;
 
     if (metric_text == "Euclidean"){
         mlpack::kmeans::KMeans<mlpack::metric::EuclideanDistance> k;
         try{
             Row<size_t> assignments;
-            k.Cluster(spectra_, clusters, assignments);
-            k_means_data.set_size(assignments.n_elem, 1);
+            k.Cluster(spectra_, clusters, assignments, centroids);
+            assignments.set_size(assignments.n_elem, 1);
             //assignments += ones(assignments.n_elem);
             //k_means_data_ = assignments;
             //The assignment operator no longer works in armadillo this is temp kludge
-            for (uword i = 0; i < k_means_data.n_elem; ++i){
-                k_means_data(i) = assignments(i) + 1.0;
+            for (uword i = 0; i < assignments.n_elem; ++i){
+                assignments(i) = assignments(i) + 1.0;
             }
         }
         catch(exception e){
@@ -1857,13 +1858,13 @@ void VespucciDataset::KMeans(size_t clusters, QString metric_text, QString name)
         mlpack::kmeans::KMeans<mlpack::metric::ManhattanDistance> k;
         try{
             Row<size_t> assignments;
-            k.Cluster(spectra_, clusters, assignments);
-            k_means_data.set_size(assignments.n_elem, 1);
+            k.Cluster(spectra_, clusters, assignments, centroids);
+            assignments.set_size(assignments.n_elem, 1);
             //assignments += ones(assignments.n_elem);
             //k_means_data_ = assignments;
             //The assignment operator no longer works in armadillo this is temp kludge
-            for (uword i = 0; i < k_means_data.n_elem; ++i){
-                k_means_data(i) = assignments(i) + 1.0;
+            for (uword i = 0; i < assignments.n_elem; ++i){
+                assignments(i) = assignments(i) + 1.0;
             }
         }
         catch(exception e){
@@ -1877,13 +1878,13 @@ void VespucciDataset::KMeans(size_t clusters, QString metric_text, QString name)
         mlpack::kmeans::KMeans<mlpack::metric::ChebyshevDistance> k;
         try{
             Row<size_t> assignments;
-            k.Cluster(spectra_, clusters, assignments);
-            k_means_data.set_size(assignments.n_elem, 1);
+            k.Cluster(spectra_, clusters, assignments, centroids);
+            assignments.set_size(assignments.n_elem, 1);
             //assignments += ones(assignments.n_elem);
             //k_means_data_ = assignments;
             //The assignment operator no longer works in armadillo this is temp kludge
-            for (uword i = 0; i < k_means_data.n_elem; ++i){
-                k_means_data(i) = assignments(i) + 1.0;
+            for (uword i = 0; i < assignments.n_elem; ++i){
+                assignments(i) = assignments(i) + 1.0;
             }
         }
         catch(exception e){
@@ -1897,13 +1898,13 @@ void VespucciDataset::KMeans(size_t clusters, QString metric_text, QString name)
         mlpack::kmeans::KMeans<mlpack::metric::SquaredEuclideanDistance> k;
         try{
             Row<size_t> assignments;
-            k.Cluster(spectra_, clusters, assignments);
-            k_means_data.set_size(assignments.n_elem, 1);
+            k.Cluster(spectra_, clusters, assignments, centroids);
+            assignments.set_size(assignments.n_elem, 1);
             //assignments += ones(assignments.n_elem);
             //k_means_data_ = assignments;
             //The assignment operator no longer works in armadillo this is temp kludge
-            for (uword i = 0; i < k_means_data.n_elem; ++i){
-                k_means_data(i) = assignments(i) + 1.0;
+            for (uword i = 0; i < assignments.n_elem; ++i){
+                assignments(i) = assignments(i) + 1.0;
             }
         }
         catch(exception e){
@@ -1924,7 +1925,8 @@ void VespucciDataset::KMeans(size_t clusters, QString metric_text, QString name)
         log_text_stream_ << clusters << endl;
     }
     QSharedPointer<AnalysisResults> results(new AnalysisResults(name, "k-Means Analysis"));
-    results->AddMatrix("Assignments", k_means_data);
+    results->AddMatrix("Assignments", assignments);
+    results->AddMatrix("Centroids", centroids);
     analysis_results_.append(results);
     workspace->UpdateModel();
 }

--- a/VespucciLibrary/VespucciLibrary.pro
+++ b/VespucciLibrary/VespucciLibrary.pro
@@ -95,7 +95,8 @@ SOURCES +=\
     src/Math/Quantification/quantification.cpp \
     src/Math/Stats/confidenceinterval.cpp \
     src/Math/Stats/hyptothesistests.cpp \
-    src/Math/PeakFinding/kernelpeakfinding.cpp
+    src/Math/PeakFinding/kernelpeakfinding.cpp \
+    src/Math/Accessory/distancemetricwrapper.cpp
 
 
 HEADERS  += \
@@ -124,7 +125,8 @@ HEADERS  += \
     include/Math/Quantification/correlation.h \
     include/Math/Stats/confidenceinterval.h \
     include/Math/Stats/hypothesistests.h \
-    include/Math/PeakFinding/kernelpeakfinding.h
+    include/Math/PeakFinding/kernelpeakfinding.h \
+    include/Math/Accessory/distancemetricwrapper.h
 
 #For all platforms:
 INCLUDEPATH += $$PWD/include

--- a/VespucciLibrary/include/Math/Accessory/accessory.h
+++ b/VespucciLibrary/include/Math/Accessory/accessory.h
@@ -74,9 +74,7 @@ namespace Vespucci
 
         VESPUCCI_EXPORT double CalcPoly(const double x, const arma::vec &coefs);
 
-        VESPUCCI_EXPORT arma::vec RepresentativeSpectrum(const mat &spectra, uword &index, std::string metric_name="euclidean", std::string center="centroid");
-
-
+        VESPUCCI_EXPORT arma::vec RepresentativeSpectrum(const arma::mat &spectra, arma::uword &index, std::string metric_name="euclidean", std::string center="centroid");
 
 
         //Abscissa transforms

--- a/VespucciLibrary/include/Math/Accessory/accessory.h
+++ b/VespucciLibrary/include/Math/Accessory/accessory.h
@@ -73,7 +73,12 @@ namespace Vespucci
         VESPUCCI_EXPORT arma::umat GetClosestValues(arma::vec query, arma::vec target, const arma::uword k=5);
 
         VESPUCCI_EXPORT double CalcPoly(const double x, const arma::vec &coefs);
-\
+
+        VESPUCCI_EXPORT arma::vec RepresentativeSpectrum(const mat &spectra, uword &index, std::string metric_name="euclidean", std::string center="centroid");
+
+
+
+
         //Abscissa transforms
         VESPUCCI_EXPORT arma::vec WavelengthToFrequency(const arma::vec &x, double freq_factor, double wl_factor);
         VESPUCCI_EXPORT arma::vec FrequencyToWavelength(const arma::vec &x, double wl_factor, double freq_factor);

--- a/VespucciLibrary/include/Math/Accessory/distancemetricwrapper.h
+++ b/VespucciLibrary/include/Math/Accessory/distancemetricwrapper.h
@@ -1,0 +1,43 @@
+/*******************************************************************************
+    Copyright (C) 2014-2016 Wright State University - All Rights Reserved
+    Daniel P. Foose - Maintainer/Lead Developer
+
+    This file is part of Vespucci.
+
+    Vespucci is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Vespucci is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Vespucci.  If not, see <http://www.gnu.org/licenses/>.
+*******************************************************************************/
+#ifndef DISTANCEMETRICWRAPPER_H
+#define DISTANCEMETRICWRAPPER_H
+#include "Global/libvespucci.h"
+#include <mlpack/core.hpp>
+
+namespace Vespucci{
+    namespace Math{
+        class VESPUCCI_EXPORT DistanceMetricWrapper
+        {
+            public:
+                DistanceMetricWrapper(std::string metric_description);
+                double Evaluate(arma::vec &first, arma::vec &second);
+            private:
+                std::string metric_description_;
+                mlpack::metric::ChebyshevDistance chebyshev_;
+                mlpack::metric::EuclideanDistance euclidean_;
+                mlpack::metric::ManhattanDistance manhattan_;
+                mlpack::metric::SquaredEuclideanDistance squared_euclidean_;
+        };
+    }
+}
+
+
+#endif // DISTANCEMETRICWRAPPER_H

--- a/VespucciLibrary/src/Global/vespucci.cpp
+++ b/VespucciLibrary/src/Global/vespucci.cpp
@@ -22,6 +22,7 @@
 #include <QtSvg>
 #include <cstdlib>
 #include <QProcess>
+#include <climits>
 
 
 ///
@@ -234,7 +235,8 @@ void Vespucci::ResetDataset(arma::mat &spectra, arma::vec &x, arma::vec &y, arma
 /// \brief Vespucci::CleanString
 /// \param in
 /// \return
-///
+/// Remove any tabs or commas from an input string so armadillo parses it properly.
+/// This function is probably not necessary
 std::string Vespucci::CleanString(const std::string &in)
 {
     std::string out;

--- a/VespucciLibrary/src/Math/Accessory/distancemetricwrapper.cpp
+++ b/VespucciLibrary/src/Math/Accessory/distancemetricwrapper.cpp
@@ -19,7 +19,7 @@
 *******************************************************************************/
 #include "Math/Accessory/distancemetricwrapper.h"
 
-Vespucci::Math::DistanceMetricWrapper::DistanceMetricWrapper(std::__1::string metric_description)
+Vespucci::Math::DistanceMetricWrapper::DistanceMetricWrapper(std::string metric_description)
     : metric_description_(metric_description){}
 
 double Vespucci::Math::DistanceMetricWrapper::Evaluate(arma::vec &first, arma::vec &second)

--- a/VespucciLibrary/src/Math/Accessory/distancemetricwrapper.cpp
+++ b/VespucciLibrary/src/Math/Accessory/distancemetricwrapper.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+    Copyright (C) 2014-2016 Wright State University - All Rights Reserved
+    Daniel P. Foose - Maintainer/Lead Developer
+
+    This file is part of Vespucci.
+
+    Vespucci is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Vespucci is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Vespucci.  If not, see <http://www.gnu.org/licenses/>.
+*******************************************************************************/
+#include "Math/Accessory/distancemetricwrapper.h"
+
+Vespucci::Math::DistanceMetricWrapper::DistanceMetricWrapper(std::__1::string metric_description)
+    : metric_description_(metric_description){}
+
+double Vespucci::Math::DistanceMetricWrapper::Evaluate(arma::vec &first, arma::vec &second)
+{
+    if (metric_description_ == "squaredeuclidean")
+        return squared_euclidean_.Evaluate(first, second);
+    else if (metric_description_ == "manhattan")
+        return manhattan_.Evaluate(first, second);
+    else if (metric_description_ == "chebyshev")
+        return chebyshev_.Evaluate(first, second);
+    else return euclidean_.Evaluate(first, second);
+}

--- a/VespucciLibrary/src/Math/Quantification/quantification.cpp
+++ b/VespucciLibrary/src/Math/Quantification/quantification.cpp
@@ -144,7 +144,16 @@ arma::mat Vespucci::Math::Quantification::QuantifyPeakMat(const arma::mat &spect
     //total_baselines.set_size(spectra.n_cols, )
     inflection_baselines.set_size(spectra.n_cols);
 
-    for (arma::uword i = 0; i < spectra.n_cols; ++i){
+#ifdef _WIN32
+  #pragma omp parallel for default(none) \
+      shared(spectra, inflection_baselines, total_baselines, results)
+     for (intmax_t i = 0; i < (intmax_t) spectra.n_cols; ++i)
+#else
+  #pragma omp parallel for default(none) \
+      shared(spectra, inflection_baselines, total_baselines, results)
+    for (size_t i = 0; i < spectra.n_cols; ++ i)
+#endif
+    {
         double temp_min = min;
         double temp_max = max;
         arma::mat total_baseline;

--- a/buildall.pro
+++ b/buildall.pro
@@ -5,5 +5,6 @@ QT       += widgets printsupport
 QT       += svg
 !win32: CONFIG   += shared debug_and_release c++11
 win32: CONFIG += shared release force_debug_info c++11
+win32: DEFINES += ARMA_32BIT_WORD
 Vespucci.depends = VespucciLibrary
 Test.depends = Vespucci VespucciLibrary


### PR DESCRIPTION
Added storage of centroids in kMeans, parallelized `QuantifyPeakMat` (addressing Issue #12), added function to find "representative spectrum", the point closest to the centroid or medoid of the entire dataset. Created a distance metric wrapper to calculate distances using four mlpack `LMetric` types (Chebyshev, Euclidean, Squared Euclidean and Manhattan), so we don't have to dump metric selection into a bunch of if statements.
