### PR TITLE
Univariate improvements and windows build fixes

### DIFF
--- a/Test/Test.pro
+++ b/Test/Test.pro
@@ -118,6 +118,9 @@ macx{
     LIBS += -L/usr/local/lib/ -lhdf5
     PRE_TARGETDEPS += /usr/local/lib/libhdf5.a
 
+    LIBS += -L/usr/local/lib -lhdf5_cpp
+    PRE_TARGETDEPS += /usr/local/lib/libhdf5_cpp.a
+
     LIBS += -L$$PWD/../../quazip/lib/ -lquazip
     INCLUDEPATH += $$PWD/../../quazip/include
     DEPENDPATH += $$PWD/../../quazip/include

--- a/Test/main.cpp
+++ b/Test/main.cpp
@@ -21,6 +21,9 @@
 #include "testahca.h"
 #include "testdatamodel.h"
 #include <QtTest/QtTest>
+#include "Data/Dataset/vespuccidataset.h"
+#include <H5Cpp.h>
+
 int main()
 {
 
@@ -28,3 +31,5 @@ int main()
     QTest::qExec(&ahca_test);
     return 0;
 }
+
+

--- a/Vespucci/Data/Analysis/univariatedata.cpp
+++ b/Vespucci/Data/Analysis/univariatedata.cpp
@@ -43,6 +43,7 @@ void UnivariateData::Apply(double left_bound, double right_bound, uword bound_wi
     AddColumns(keys, results);
     AddMatrix("Inflection Points", inflection_points);
     AddMatrix("Baselines", baselines);
+    AddMatrix("Inflection Baselines", Vespucci::Math::Quantification::ConvertInflectionBaselines(inflection_baselines));
     AddField("Inflection Baselines", inflection_baselines);
 }
 
@@ -90,6 +91,8 @@ void UnivariateData::Apply(double first_left_bound, double first_right_bound, do
     AddMatrix("Second Region Baselines", second_baselines);
     AddMatrix("First Region Inflection Points", first_inflection_points);
     AddMatrix("Second Region Inflection Points", second_inflection_points);
+    AddMatrix("First Region Inflection Baselines", Vespucci::Math::Quantification::ConvertInflectionBaselines(inflection_first_baselines));
+    AddMatrix("Second Region Inflection Baselines", Vespucci::Math::Quantification::ConvertInflectionBaselines(inflection_second_baselines));
 
 }
 

--- a/Vespucci/Data/Dataset/vespuccidataset.cpp
+++ b/Vespucci/Data/Dataset/vespuccidataset.cpp
@@ -1,4 +1,4 @@
-/*******************************************************************************
+ /*******************************************************************************
     Copyright (C) 2014-2016 Wright State University - All Rights Reserved
     Daniel P. Foose - Maintainer/Lead Developer
 

--- a/Vespucci/Data/Dataset/vespuccidataset.cpp
+++ b/Vespucci/Data/Dataset/vespuccidataset.cpp
@@ -543,15 +543,10 @@ VespucciDataset::VespucciDataset(QString name,
 {
     workspace_ = main_window->workspace_ptr();
     AddAnalysisResult(auxiliary_matrices_);
-    //map_list_model_ = new MapListModel(main_window, this);
     state_changed_ = true;
     non_spatial_ = true;
     meta_ = true;
     map_loading_count_ = 0;
-    //principal_components_calculated_ = false;
-    //mlpack_pca_calculated_ = false;
-    //partial_least_squares_calculated_ = false;
-    //vertex_components_calculated_ = false;
     z_scores_calculated_ = false;
     directory_ = directory;
     name_ = name;

--- a/Vespucci/GUI/Processing/bulkconversiondialog.cpp
+++ b/Vespucci/GUI/Processing/bulkconversiondialog.cpp
@@ -5,6 +5,7 @@
 #include "Data/Import/textimport.h"
 #include "GUI/Display/reportmessagedialog.h"
 
+
 BulkConversionDialog::BulkConversionDialog(MainWindow *parent,
                                            QSharedPointer<VespucciWorkspace> ws) :
     QDialog(parent),
@@ -66,8 +67,10 @@ void BulkConversionDialog::on_buttonBox_accepted()
       case 1:
         intype = long_text;
         break;
-      case 2: default:
+      case 2:
         intype = binary;
+      case 3: default:
+        intype = oldbinary;
     }
 
     switch (ui->outputComboBox->currentIndex()){
@@ -100,7 +103,6 @@ vector<string> BulkConversionDialog::SaveFiles(vector<string> infile_names, stri
     mat spectra;
     vec x, y, abscissa;
     bool comma_decimals = false;
-    QProgressDialog *progress = new QProgressDialog("Loading file", "Cancel", 0, 100);
     switch (intype){
       case wide_text:
         for(strvec_it it = infile_names.begin(); it!=infile_names.end(); ++it){
@@ -124,7 +126,6 @@ vector<string> BulkConversionDialog::SaveFiles(vector<string> infile_names, stri
                     QFileInfo(QString::fromStdString(*it)).baseName().toStdString();
             WriteFile(outtype, outfilename, spectra, abscissa, x, y);
         }//for (infile)
-        progress->close();
         break;
 
       case long_text:
@@ -150,15 +151,27 @@ vector<string> BulkConversionDialog::SaveFiles(vector<string> infile_names, stri
 
             WriteFile(outtype, outfilename, spectra, abscissa, x, y);
         }//for (infiles)
-        progress->close();
         break;
+      case binary:
+        for (strvec_it it = infile_names.begin(); it != infile_names.end(); ++it){
+            QSharedPointer<VespucciDataset> dataset(new VespucciDataset(QString::fromStdString(*it), workspace_->main_window(), workspace_));
+            ok = dataset->ConstructorCancelled();
+            if (!ok){
+                skipped_files.push_back(*it);
+                infile_names.erase(it);
+            }
 
-      case binary: default:
+            string outfilename =
+                    outfile_path + "/" +
+                    QFileInfo(QString::fromStdString(*it)).fileName().toStdString();
+            WriteFile(outtype, outfilename, dataset->spectra(), dataset->abscissa(), dataset->x(), dataset->y());
+      }
+      case oldbinary: default:
         for(strvec_it it = infile_names.begin(); it!=infile_names.end(); ++it){
-            ok = BinaryImport::ImportOldVespucciBinary(*it,
-                                               spectra,
-                                               abscissa,
-                                               x, y);
+            ok = BinaryImport::ImportVespucciBinary(*it,
+                                                    spectra,
+                                                    abscissa,
+                                                    x, y);
             if (!ok){
                 skipped_files.push_back(*it);
                 infile_names.erase(it);
@@ -170,7 +183,6 @@ vector<string> BulkConversionDialog::SaveFiles(vector<string> infile_names, stri
             WriteFile(outtype, outfilename, spectra, abscissa, x, y);
         }//for (infiles)
     }//switch (intype)
-    delete progress; //not sure what happens to a QProgress dialog instantiated with null parent
     return skipped_files;
 }
 
@@ -207,8 +219,10 @@ void BulkConversionDialog::WriteFile(const arma::file_type &type,
     case csv_ascii: case raw_ascii:
         Vespucci::SaveText(filename, spectra, x, y, abscissa, type);
         break;
+    case hdf5_binary:
+        SaveHDF5(filename, spectra, abscissa, x, y);
     case arma_binary: default:
-        Vespucci::SaveVespucciBinary(filename + ".vds", spectra, x, y, abscissa);
+        Vespucci::SaveOldVespucciBinary(filename + ".vds", spectra, x, y, abscissa);
     }
 }
 
@@ -217,4 +231,17 @@ void BulkConversionDialog::on_BrowsePushButton_clicked()
     QString path = QFileDialog::getExistingDirectory(this, "Select Folder",
                                                      workspace_->directory());
     ui->targetLineEdit->setText(path);
+}
+
+bool BulkConversionDialog::SaveHDF5(string filename,
+                                    const mat &spectra,
+                                    const vec &abscissa,
+                                    const vec &x,
+                                    const vec &y) const
+{
+    VespucciDataset dataset(QString::fromStdString(filename),
+                           workspace_->main_window(),
+                           workspace_->directory_ptr());
+    dataset.SetData(spectra, abscissa, x, y);
+    dataset.Save(QString::fromStdString(filename));
 }

--- a/Vespucci/GUI/Processing/bulkconversiondialog.cpp
+++ b/Vespucci/GUI/Processing/bulkconversiondialog.cpp
@@ -155,7 +155,7 @@ vector<string> BulkConversionDialog::SaveFiles(vector<string> infile_names, stri
 
       case binary: default:
         for(strvec_it it = infile_names.begin(); it!=infile_names.end(); ++it){
-            ok = BinaryImport::ImportVespucciBinary(*it,
+            ok = BinaryImport::ImportOldVespucciBinary(*it,
                                                spectra,
                                                abscissa,
                                                x, y);

--- a/Vespucci/GUI/Processing/bulkconversiondialog.cpp
+++ b/Vespucci/GUI/Processing/bulkconversiondialog.cpp
@@ -243,5 +243,5 @@ bool BulkConversionDialog::SaveHDF5(string filename,
                            workspace_->main_window(),
                            workspace_->directory_ptr());
     dataset.SetData(spectra, abscissa, x, y);
-    dataset.Save(QString::fromStdString(filename));
+    return dataset.Save(QString::fromStdString(filename));
 }

--- a/Vespucci/GUI/Processing/bulkconversiondialog.h
+++ b/Vespucci/GUI/Processing/bulkconversiondialog.h
@@ -31,7 +31,12 @@ private:
     Ui::BulkConversionDialog *ui;
     QSharedPointer<VespucciWorkspace> workspace_;
 
-    enum infile_type{long_text, wide_text, binary};
+    bool SaveHDF5(string filename,
+                  const mat &spectra,
+                  const vec &abscissa,
+                  const vec &x,
+                  const vec &y) const;
+    enum infile_type{long_text, wide_text, binary, oldbinary};
     enum outfile_type{v_binary, text};
     vector<string> SaveFiles(vector<string> infile_names,
                              string outfile_path,

--- a/Vespucci/GUI/Processing/bulkconversiondialog.ui
+++ b/Vespucci/GUI/Processing/bulkconversiondialog.ui
@@ -80,6 +80,11 @@
        <string>Vespucci Binary</string>
       </property>
      </item>
+     <item>
+      <property name="text">
+       <string>Old Vespucci Binary</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="5" column="0">

--- a/Vespucci/GUI/Processing/datasetimportdialog.cpp
+++ b/Vespucci/GUI/Processing/datasetimportdialog.cpp
@@ -120,14 +120,38 @@ void DatasetImportDialog::on_buttonBox_accepted()
         format = "LongTabDel";
     else if (data_format_string == "Long Text (CSV)")
         format = "LongCSV";
+    else if (data_format_string == "Old Vespucci Dataset")
+        format = "OldVBinary";
     else
         return;
 
 
 
-    //bool remove_at_position = false;
-    //int temp_position=0;
-    //int position;
+    if (data_format_string == "Old Vespucci Dataset"){
+        try{
+            mat spectra;
+            vec abscissa, x, y;
+            BinaryImport::ImportOldVespucciBinary(filename.toStdString(),
+                                                  spectra,
+                                                  abscissa,
+                                                  x, y);
+            QSharedPointer<VespucciDataset> dataset(new VespucciDataset(name,
+                                                                   workspace_->main_window(),
+                                                                   workspace_->directory_ptr()));
+            dataset->SetData(spectra, abscissa, x, y);
+            if (!dataset->ConstructorCancelled()){
+                workspace_->AddDataset(dataset);
+                workspace_->set_directory(file_info.dir().absolutePath());
+                dataset.clear();
+            }
+        }catch(exception e){
+            workspace_->main_window()->DisplayExceptionWarning(e);
+            workspace_->RemoveDataset(name);
+            return;
+        }
+        close();
+        return;
+    }
     bool swap = ui->swapCheckBox->isChecked();
 
     try{
@@ -147,6 +171,7 @@ void DatasetImportDialog::on_buttonBox_accepted()
     }
     catch(exception e){
         workspace_->main_window()->DisplayExceptionWarning(e);
+        workspace_->RemoveDataset(name);
         return;
     }
 

--- a/Vespucci/GUI/Processing/datasetimportdialog.ui
+++ b/Vespucci/GUI/Processing/datasetimportdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>399</width>
-    <height>387</height>
+    <height>372</height>
    </rect>
   </property>
   <property name="font">
@@ -16,7 +16,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Load Dataset</string>
+   <string>Import Dataset from File</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -100,7 +100,7 @@
         </item>
         <item>
          <property name="text">
-          <string>Vespucci Dataset</string>
+          <string>Old Vespucci Dataset</string>
          </property>
         </item>
        </widget>

--- a/Vespucci/GUI/Processing/stitchimportdialog.cpp
+++ b/Vespucci/GUI/Processing/stitchimportdialog.cpp
@@ -34,7 +34,6 @@ bool StitchImportDialog::LoadDatasets(field<string> filenames, mat &spectra, vec
     vec current_x, current_y, current_abscissa;
     bool ok;
     bool two_dim = datasets.n_rows > 1 && datasets.n_cols > 1;
-    QProgressDialog progress(this);
     for (uword j = 0; j < filenames.n_cols; ++j){
         for (uword i = 0; i < filenames.n_rows; ++i){
             QString filename;
@@ -44,7 +43,7 @@ bool StitchImportDialog::LoadDatasets(field<string> filenames, mat &spectra, vec
                 filename = path_ + "/" + QString::fromStdString(filenames(i));
             if (type == "Vespucci Dataset"){
 
-                ok = BinaryImport::ImportOldVespucciBinary(filename.toStdString(),
+                ok = BinaryImport::ImportVespucciBinary(filename.toStdString(),
                                                         current_spectra,
                                                         current_abscissa,
                                                         current_x,

--- a/Vespucci/GUI/Processing/stitchimportdialog.cpp
+++ b/Vespucci/GUI/Processing/stitchimportdialog.cpp
@@ -44,7 +44,7 @@ bool StitchImportDialog::LoadDatasets(field<string> filenames, mat &spectra, vec
                 filename = path_ + "/" + QString::fromStdString(filenames(i));
             if (type == "Vespucci Dataset"){
 
-                ok = BinaryImport::ImportVespucciBinary(filename.toStdString(),
+                ok = BinaryImport::ImportOldVespucciBinary(filename.toStdString(),
                                                         current_spectra,
                                                         current_abscissa,
                                                         current_x,

--- a/Vespucci/Vespucci.pro
+++ b/Vespucci/Vespucci.pro
@@ -401,6 +401,22 @@ win32:!win32-g++{
     CONFIG += release force_debug_info
     QMAKE_CXXFLAGS += /MP /openmp
 
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibhdf5_cpp
+    INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
+    DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libhdf5_cpp.lib
+
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibhdf5
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libhdf5.lib
+
+
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5_cpp
+    INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
+    DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
+
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5_cpp.lib
+
+
     LIBS += -L$$OUT_PWD/../VespucciLibrary/release -llibvespucci
     PRE_TARGETDEPS += $$OUT_PWD/../VespucciLibrary/release/libvespucci.lib
 
@@ -414,18 +430,15 @@ win32:!win32-g++{
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/armadillo/include
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/armadillo/lib/armadillo.lib
 
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5.lib
+
     LIBS += -L$$PWD/../../Vespucci_dependencies/OpenBLAS/ -llibopenblas
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/OpenBLAS/libopenblas.lib
 
     LIBS += -L$$PWD/../../Vespucci_dependencies/LAPACK/ -llapack_x64
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/LAPACK/lapack_x64.lib
 
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5_cpp
-    INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5.lib
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5_cpp.lib
 
     INCLUDEPATH += $$PWD/../../Vespucci_dependencies/boost_1_61_0
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/boost_1_61_0
@@ -455,15 +468,15 @@ win32:!win32-g++{
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/yaml-cpp/include
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/yaml-cpp/lib/libyaml-cppmdd.lib
 
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lzlib
-    INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/zlib.lib
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibzlib
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libzlib.lib
+
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibszip
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libszip.lib
 
     RC_ICONS=$$PWD/vespuccilogo.ico
 }
 
 
-
-
-
+LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibzlib
+PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libzlib.lib

--- a/Vespucci/Vespucci.pro
+++ b/Vespucci/Vespucci.pro
@@ -409,14 +409,6 @@ win32:!win32-g++{
     LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibhdf5
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libhdf5.lib
 
-
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5_cpp
-    INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5_cpp.lib
-
-
     LIBS += -L$$OUT_PWD/../VespucciLibrary/release -llibvespucci
     PRE_TARGETDEPS += $$OUT_PWD/../VespucciLibrary/release/libvespucci.lib
 
@@ -429,9 +421,6 @@ win32:!win32-g++{
     INCLUDEPATH += $$PWD/../../Vespucci_dependencies/armadillo/include
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/armadillo/include
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/armadillo/lib/armadillo.lib
-
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5.lib
 
     LIBS += -L$$PWD/../../Vespucci_dependencies/OpenBLAS/ -llibopenblas
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/OpenBLAS/libopenblas.lib
@@ -478,5 +467,4 @@ win32:!win32-g++{
 }
 
 
-LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibzlib
-PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libzlib.lib
+

--- a/VespucciLibrary/VespucciLibrary.pro
+++ b/VespucciLibrary/VespucciLibrary.pro
@@ -246,10 +246,13 @@ win32:!win32-g++{
     LIBS += -L$$PWD/../../Vespucci_dependencies/LAPACK/ -llapack_x64
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/LAPACK/lapack_x64.lib
 
-    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -lhdf5
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib -llibhdf5_cpp
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libhdf5_cpp.lib
+
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibhdf5
     INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
-    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/hdf5.lib
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libhdf5.lib
 
     INCLUDEPATH += $$PWD/../../Vespucci_dependencies/boost_1_61_0
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/boost_1_61_0
@@ -283,4 +286,8 @@ win32:!win32-g++{
     INCLUDEPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
     DEPENDPATH += $$PWD/../../Vespucci_dependencies/HDF5/include
     PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/zlib.lib
+
+    LIBS += -L$$PWD/../../Vespucci_dependencies/HDF5/lib/ -llibszip
+    PRE_TARGETDEPS += $$PWD/../../Vespucci_dependencies/HDF5/lib/libszip.lib
 }
+

--- a/VespucciLibrary/VespucciLibrary.pro
+++ b/VespucciLibrary/VespucciLibrary.pro
@@ -144,10 +144,10 @@ unix:!macx{
     QMAKE_RPATHDIR += $$(QTDIR)/lib
     LIBS += -L$$PWD/../../mlpack/lib -lmlpack
     LIBS += -L$$PWD/../../armadillo/lib -larmadillo
-    LIBS += -L$$PWD/../../hdf5/lib -lhdf5
     LIBS += -L$$PWD/../../hdf5/lib -lhdf5_cpp
-    PRE_TARGETDEPS += $$PWD/../../hdf5/lib/libhdf5.a
+    LIBS += -L$$PWD/../../hdf5/lib -lhdf5
     PRE_TARGETDEPS += $$PWD/../../hdf5/lib/libhdf5_cpp.a
+    PRE_TARGETDEPS += $$PWD/../../hdf5/lib/libhdf5.a
     INCLUDEPATH += $$PWD/../../hdf5/include
     DEPENDPATH += $$PWD/../../hdf5/include
     LIBS += -L/usr/lib -lblas
@@ -207,6 +207,7 @@ macx{
 
     LIBS += -framework Accelerate
 
+    LIBS += -L/usr/local/opt/hdf5/lib -lhdf5_cpp
     LIBS += -L/usr/local/opt/hdf5/lib -lhdf5
 
     INCLUDEPATH += $$PWD/../../quazip/include

--- a/VespucciLibrary/include/Data/Import/binaryimport.h
+++ b/VespucciLibrary/include/Data/Import/binaryimport.h
@@ -27,10 +27,14 @@
 
 namespace BinaryImport
 {
-    VESPUCCI_EXPORT bool ImportVespucciBinary(std::string filename,
+    VESPUCCI_EXPORT bool ImportOldVespucciBinary(std::string filename,
                               arma::mat &spectra,
                               arma::vec &abscissa,
                               arma::vec &x, arma::vec &y);
+    VESPUCCI_EXPORT bool ImportVespucciBinary(std::string filename,
+                                               arma::mat &spectra,
+                                               arma::vec &abscissa,
+                                               arma::vec &x, arma::vec &y);
 }
 
 #endif // BINARYIMPORT_H

--- a/VespucciLibrary/include/Global/vespucci.h
+++ b/VespucciLibrary/include/Global/vespucci.h
@@ -17,7 +17,7 @@
 namespace Vespucci{
 
     VESPUCCI_EXPORT bool SaveHDF5Obj(std::map<std::string, arma::mat*> objects, const std::string filename);
-    VESPUCCI_EXPORT bool SaveVespucciBinary(std::string filename, const arma::mat &spectra, const arma::vec &x, const arma::vec &y, const arma::vec &abscissa);
+    VESPUCCI_EXPORT bool SaveOldVespucciBinary(std::string filename, const arma::mat &spectra, const arma::vec &x, const arma::vec &y, const arma::vec &abscissa);
     VESPUCCI_EXPORT bool SaveText(std::string basename, const arma::mat &spectra, const arma::vec &x, const arma::vec &y, const arma::vec &abscissa, arma::file_type type);
     VESPUCCI_EXPORT bool StitchDatasets(const arma::field<arma::field<arma::mat> > &datasets, arma::mat &spectra, arma::vec &x, arma::vec &y, arma::vec &abscissa);
     VESPUCCI_EXPORT void ResetDataset(arma::mat &spectra, arma::vec &x, arma::vec &y, arma::vec &abscissa);

--- a/VespucciLibrary/include/Math/Quantification/quantification.h
+++ b/VespucciLibrary/include/Math/Quantification/quantification.h
@@ -31,6 +31,7 @@ namespace Vespucci{
         namespace Quantification{
             VESPUCCI_EXPORT arma::rowvec QuantifyPeak(const arma::vec &spectrum, const arma::vec &abscissa, double &min, double &max, arma::uword bound_window, arma::mat &total_baseline, arma::mat &inflection_baseline);
             VESPUCCI_EXPORT arma::mat QuantifyPeakMat(const arma::mat &spectra, const arma::vec &abscissa, double &min, double &max, arma::uword bound_window, arma::mat &total_baselines, arma::field<arma::mat> &inflection_baselines);
+            VESPUCCI_EXPORT arma::mat ConvertInflectionBaselines(const arma::field<arma::mat> &inflection_baselines);
         }
     }
 }

--- a/VespucciLibrary/src/Data/Import/binaryimport.cpp
+++ b/VespucciLibrary/src/Data/Import/binaryimport.cpp
@@ -22,9 +22,9 @@
 
 #include <H5Cpp.h>
 bool BinaryImport::ImportVespucciBinary(std::string filename,
-                                           arma::mat &spectra,
-                                           arma::vec &abscissa,
-                                           arma::vec &x, arma::vec &y)
+                                        arma::mat &spectra,
+                                        arma::vec &abscissa,
+                                        arma::vec &x, arma::vec &y)
 {
     Vespucci::ResetDataset(spectra, x, y, abscissa);
     using namespace H5;

--- a/VespucciLibrary/src/Data/Import/binaryimport.cpp
+++ b/VespucciLibrary/src/Data/Import/binaryimport.cpp
@@ -19,11 +19,12 @@
 *******************************************************************************/
 #include "Data/Import/binaryimport.h"
 #include "Global/vespucci.h"
+
 #include <H5Cpp.h>
 bool BinaryImport::ImportVespucciBinary(std::string filename,
-                                        arma::mat &spectra,
-                                        arma::vec &abscissa,
-                                        arma::vec &x, arma::vec &y)
+                                           arma::mat &spectra,
+                                           arma::vec &abscissa,
+                                           arma::vec &x, arma::vec &y)
 {
     Vespucci::ResetDataset(spectra, x, y, abscissa);
     using namespace H5;
@@ -72,6 +73,25 @@ bool BinaryImport::ImportVespucciBinary(std::string filename,
         arma::uvec sorted_indices = arma::stable_sort_index(abscissa);
         abscissa = abscissa.rows(sorted_indices);
         spectra = spectra.rows(sorted_indices);
+    }
+    return success;
+
+}
+
+bool BinaryImport::ImportOldVespucciBinary(std::string filename,
+                                           arma::mat &spectra,
+                                           arma::vec &abscissa,
+                                           arma::vec &x, arma::vec &y)
+{
+    Vespucci::ResetDataset(spectra, x, y, abscissa);
+    arma::field<arma::mat> input_data;
+    bool success = input_data.load(filename);
+    std::cout << (success ? "success" : "failure") << std::endl;
+    if(success){
+        spectra = input_data(0);
+        abscissa = input_data(1);
+        x = input_data(2);
+        y = input_data(3);
     }
     return success;
 }

--- a/VespucciLibrary/src/Global/vespucci.cpp
+++ b/VespucciLibrary/src/Global/vespucci.cpp
@@ -33,7 +33,7 @@
 /// \param abscissa
 /// \return
 ///
-bool Vespucci::SaveVespucciBinary(std::string filename, const arma::mat &spectra, const arma::vec &x, const arma::vec &y, const arma::vec &abscissa)
+bool Vespucci::SaveOldVespucciBinary(std::string filename, const arma::mat &spectra, const arma::vec &x, const arma::vec &y, const arma::vec &abscissa)
 {
     bool success;
     try{

--- a/VespucciLibrary/src/Math/Quantification/quantification.cpp
+++ b/VespucciLibrary/src/Math/Quantification/quantification.cpp
@@ -153,6 +153,7 @@ arma::mat Vespucci::Math::Quantification::QuantifyPeakMat(const arma::mat &spect
     total_baselines.clear();
     //total_baselines.set_size(spectra.n_cols, )
     inflection_baselines.set_size(spectra.n_cols);
+    arma::field<arma::mat> total_baselines_tmp(spectra.n_cols);
 
 #ifdef _WIN32
   #pragma omp parallel for default(none) \
@@ -170,13 +171,15 @@ arma::mat Vespucci::Math::Quantification::QuantifyPeakMat(const arma::mat &spect
         arma::mat inflection_baseline;
         results.row(i) = Vespucci::Math::Quantification::QuantifyPeak(spectra.col(i), abscissa, temp_min, temp_max, bound_window, total_baseline, inflection_baseline);
         inflection_baselines(i) = inflection_baseline;
+        total_baselines_tmp(i) = total_baseline;
+    }
+    for (size_t i = 0; i < total_baselines_tmp.n_rows; ++i){
         if (total_baselines.n_rows){
-            total_baselines = arma::join_vert(total_baselines, total_baseline.t());
+            total_baselines = arma::join_vert(total_baselines, total_baselines_tmp(i).t());
         }
         else{
-            total_baselines = total_baseline.t();
+            total_baselines = total_baselines_tmp(i).t();
         }
-
     }
     return results;
 }

--- a/VespucciLibrary/src/Math/Quantification/quantification.cpp
+++ b/VespucciLibrary/src/Math/Quantification/quantification.cpp
@@ -69,8 +69,12 @@ arma::rowvec Vespucci::Math::Quantification::QuantifyPeak(const arma::vec &spect
     arma::uword window_size = max_index - min_index + 1;
     total_baseline = arma::linspace(spectrum(min_index), spectrum(max_index), window_size);
     arma::vec total_abscissa = abscissa.rows(min_index, max_index);
-    double baseline_area = arma::as_scalar(arma::trapz(abscissa_part, total_baseline));
+    arma::uvec positive_indices = arma::find(spectrum_part > total_baseline);
+    double positive_area = arma::as_scalar(arma::trapz(abscissa_part.rows(positive_indices), spectrum_part.rows(positive_indices)));
+    double baseline_area = arma::as_scalar(arma::trapz(abscissa_part.rows(positive_indices), total_baseline.rows(positive_indices)));
     total_baseline = arma::join_horiz(total_abscissa, total_baseline);
+
+
 
     arma::vec min_window = spectrum.rows(min_start, min_end);
     arma::vec max_window = spectrum.rows(max_start, max_end);
@@ -93,6 +97,7 @@ arma::rowvec Vespucci::Math::Quantification::QuantifyPeak(const arma::vec &spect
     window_size = inflection_max_index - inflection_min_index + 1;
     inflection_baseline = arma::linspace(spectrum(inflection_min_index), spectrum(inflection_max_index), window_size);
     double inf_baseline_area = arma::as_scalar(arma::trapz(abscissa_part, inflection_baseline));
+    inflection_baseline = join_horiz(abscissa.rows(inflection_min_index, inflection_max_index), inflection_baseline);
 
 
 
@@ -101,7 +106,6 @@ arma::rowvec Vespucci::Math::Quantification::QuantifyPeak(const arma::vec &spect
     arma::uword search_max_index = (inflection_max_index > max_index ? max_index : inflection_max_index);
     arma::vec region = spectrum.rows(search_min_index, search_max_index);
     arma::vec region_abscissa = abscissa.rows(search_min_index, search_max_index);
-    inflection_baseline = join_horiz(region_abscissa, region);
 
     double maximum = region.max();
     arma::uword max_pos = region.index_max();
@@ -138,7 +142,7 @@ arma::rowvec Vespucci::Math::Quantification::QuantifyPeak(const arma::vec &spect
     results(1) = maximum;
     results(2) = adj_maximum;
     results(3) = total_area;
-    results(4) = total_area - baseline_area;
+    results(4) = positive_area - baseline_area;
     results(5) = area_between_inflection;
     results(6) = area_between_inflection - inf_baseline_area;
     results(7) = fwhm;
@@ -175,12 +179,43 @@ arma::mat Vespucci::Math::Quantification::QuantifyPeakMat(const arma::mat &spect
     }
     for (size_t i = 0; i < total_baselines_tmp.n_rows; ++i){
         if (total_baselines.n_rows){
-            total_baselines = arma::join_vert(total_baselines, total_baselines_tmp(i).t());
+            total_baselines = arma::join_horiz(total_baselines, total_baselines_tmp(i).col(1));
         }
         else{
-            total_baselines = total_baselines_tmp(i).t();
+            total_baselines = total_baselines_tmp(i);
         }
     }
     return results;
 }
 
+///
+/// \brief Vespucci::Math::Quantification::ConvertInflectionBaselines
+/// \param inflection_baselines
+/// \return
+/// Create a matrix containing inflection point baselines. If a baseline does not contain a value for a particular abscissa point, the value is NaN
+/// first column will be the abscissa
+arma::mat Vespucci::Math::Quantification::ConvertInflectionBaselines(const arma::field<arma::mat> &inflection_baselines)
+{
+    arma::vec all_abscissa = inflection_baselines(0).col(0);
+
+    for (arma::uword i = 0; i < inflection_baselines.n_elem; ++i){
+        arma::vec current_baseline = inflection_baselines(i).col(0);
+        all_abscissa = arma::join_vert(all_abscissa, current_baseline);
+    }
+    arma::vec abscissa = arma::unique(all_abscissa);
+    abscissa = arma::sort(abscissa);
+    arma::mat baseline_matrix(abscissa.n_rows, inflection_baselines.n_elem);
+
+    for (arma::uword j = 0; j < inflection_baselines.n_elem; ++j){
+        arma::vec current_baseline = inflection_baselines(j).col(1);
+        arma::vec current_abscissa = inflection_baselines(j).col(0);
+        for (arma::uword i = 0; i < abscissa.n_rows; ++i){
+            arma::uvec indices = arma::find(current_abscissa == abscissa(i));
+            baseline_matrix(i, j) = (indices.n_rows > 0 ?
+                                         current_baseline(indices(0)) :
+                                         std::nan(""));
+        }
+    }
+    baseline_matrix = arma::join_horiz(abscissa, baseline_matrix);
+    return baseline_matrix;
+}

--- a/buildall.pro
+++ b/buildall.pro
@@ -8,3 +8,5 @@ win32: CONFIG += shared release force_debug_info c++11
 win32: DEFINES += ARMA_32BIT_WORD
 Vespucci.depends = VespucciLibrary
 Test.depends = Vespucci VespucciLibrary
+
+


### PR DESCRIPTION
Fixes to the windows build (this was done locally first).
Improvements to peak quantification: now only considers points of spectra that are greater than the local linear baseline. Inflection baselines are available to the user.
Support for the old Vespucci dataset format added back to DatasetImportDialog.
